### PR TITLE
nodefs-handler.js setFsWatchListener crashfix

### DIFF
--- a/lib/nodefs-handler.js
+++ b/lib/nodefs-handler.js
@@ -74,6 +74,7 @@ function setFsWatchListener(path, fullPath, options, handlers) {
     watcher = createFsWatchInstance(
       path, options, listener, errHandler, rawEmitter
     );
+    if (!watcher) return;
     return watcher.close.bind(watcher);
   }
   if (!container) {


### PR DESCRIPTION
In setFsWatchListener on !options.persistent, createFsWatchInstance returns null in some cases, and then watcher.close.bind will throw "TypeError: Cannot read property 'close' of undefined".